### PR TITLE
Vk descriptor buffer

### DIFF
--- a/Include/Vulray/Buffer.h
+++ b/Include/Vulray/Buffer.h
@@ -12,10 +12,25 @@ namespace vr
         uint64_t Size = 0;
     };
 
-    struct ImageAllocation
+
+    struct AllocatedTexelBuffer
+    {
+        AllocatedBuffer Buffer;
+        vk::Format Format = vk::Format::eUndefined;
+    };
+
+    struct AllocatedImage
     {
         VmaAllocation Allocation = nullptr;
         vk::Image Image = nullptr;
+        uint64_t Size = 0;
+    };
+
+    // an image that can be accessed by the GPU, eg a sampled image
+    struct AccessibleImage
+    {
+        vk::ImageView View = nullptr;
+        vk::ImageLayout Layout = vk::ImageLayout::eUndefined;
     };
 
     uint32_t AlignUp(uint32_t value, uint32_t alignment);

--- a/Include/Vulray/Descriptors.h
+++ b/Include/Vulray/Descriptors.h
@@ -30,9 +30,10 @@ namespace vr
     struct DescriptorItem
     {
         //constructor to initialize all fields
-        DescriptorItem(uint32_t binding, vk::DescriptorType type, vk::ShaderStageFlags stageFlags, uint32_t ArraySize, void* pItems)
+        DescriptorItem(uint32_t binding, vk::DescriptorType type, vk::ShaderStageFlags stageFlags, uint32_t ArraySize, void* pItems, uint32_t dynamicArraySize = 0)
             : Type(type), Binding(binding), BindingOffset(0), ArraySize(ArraySize), StageFlags(stageFlags),
-            pResources(reinterpret_cast<AllocatedBuffer*>(pItems)) // even if the item isn't a buffer, we can use this field since its a union and a 64-bit address
+            pResources(reinterpret_cast<AllocatedBuffer*>(pItems)), // even if the item isn't a buffer, we can use this field since its a union and a 64-bit address
+            DynamicArraySize(dynamicArraySize) 
         {
         }
 
@@ -42,9 +43,13 @@ namespace vr
 
         uint32_t BindingOffset = 0; // binding offset is filled in when creating the descriptor buffer
 
-        uint32_t ArraySize = 0; // size of the pointers array, eg 1 for a single uniform buffer or 10 for an array of 10 uniform buffers
+        uint32_t ArraySize = 0; // size of the binding array, if it is dynamic, this is the max size
         
         vk::ShaderStageFlags StageFlags = vk::ShaderStageFlagBits::eAll;
+
+        // if this is non-zero, the array is dynamic and this is the size of the dynamic array
+        // or in other words, the size of the array that p*** is pointing to
+        uint32_t DynamicArraySize = 0; 
 
         // all of these are 64 bit pointers, so we can use a union
         union

--- a/Include/Vulray/Descriptors.h
+++ b/Include/Vulray/Descriptors.h
@@ -1,92 +1,133 @@
 #pragma once
 
+#include "Vulray/Buffer.h"
+
 namespace vr
 {
 
 
+    enum class DescriptorBufferType : uint32_t
+    {
+        // These map straight to vulkan buffer usage flags
 
+        Resource = (uint32_t)vk::BufferUsageFlagBits::eResourceDescriptorBufferEXT,
+        Sampler = (uint32_t)vk::BufferUsageFlagBits::eSamplerDescriptorBufferEXT,
+        CombinedImageSampler = (uint32_t)(vk::BufferUsageFlagBits::eSamplerDescriptorBufferEXT | vk::BufferUsageFlagBits::eResourceDescriptorBufferEXT)
+    };
+
+    struct DescriptorBuffer
+    {
+        AllocatedBuffer Buffer;
+        // size of a single Descriptor set in the buffer
+        // useful for offsetting into the buffer that has multiple IDENTICAL descriptor sets and binding one of them
+        uint32_t SetCount = 0;
+        uint32_t SingleDescriptorSize = 0;
+        DescriptorBufferType Type = DescriptorBufferType::Resource;
+
+        uint32_t GetOffsetToSet(uint32_t setIndex) const { return setIndex * SingleDescriptorSize; }
+    };
+    
     struct DescriptorItem
     {
-        DescriptorItem() = default;
-        DescriptorItem(uint32_t binding,
-        vk::DescriptorType type, 
-        vk::ShaderStageFlags stageFlags, 
-        uint32_t descriptorCount = 1, 
-        void* pitems = nullptr, 
-        vk::DescriptorBindingFlagBits flags = (vk::DescriptorBindingFlagBits)0, bool dynamicArray = false)
-            : Binding(binding), Type(type), StageFlags(stageFlags), DescriptorCount(descriptorCount),  pItems(pitems), mFlags(flags), DynamicArray(dynamicArray)
-        {}
+        //constructor to initialize all fields
+        DescriptorItem(uint32_t binding, vk::DescriptorType type, vk::ShaderStageFlags stageFlags, uint32_t ArraySize, void* pItems)
+            : Type(type), Binding(binding), BindingOffset(0), ArraySize(ArraySize), StageFlags(stageFlags),
+            pResources(reinterpret_cast<AllocatedBuffer*>(pItems)) // even if the item isn't a buffer, we can use this field since its a union and a 64-bit address
+        {
+        }
+
+        vk::DescriptorType Type;
+
+        uint32_t Binding = 0;
+
+        uint32_t BindingOffset = 0; // binding offset is filled in when creating the descriptor buffer
+
+        uint32_t ArraySize = 0; // size of the pointers array, eg 1 for a single uniform buffer or 10 for an array of 10 uniform buffers
+        
+        vk::ShaderStageFlags StageFlags = vk::ShaderStageFlagBits::eAll;
+
+        // all of these are 64 bit pointers, so we can use a union
+        union
+        {
+            // for normal buffers, eg uniform buffers, storage buffers
+            // we only need the device address and size, so those fields must be set 
+            AllocatedBuffer* pResources = nullptr;
+            
+            // for image samplers, combined image samplers
+            AccessibleImage* pImages;
+
+            // for acceleration structures
+            vk::DeviceAddress* pAccelerationStructures;
+
+            // for storage texel buffers
+            AllocatedTexelBuffer* pTexelBuffers;
+        };
+        
+
 
         vk::DescriptorSetLayoutBinding GetLayoutBinding() const
         {
-            vk::DescriptorSetLayoutBinding binding;
-            binding.setBinding(Binding);
-            binding.setDescriptorCount(DescriptorCount);
-            binding.setDescriptorType(Type);
-            binding.setStageFlags(StageFlags);
-            return binding;
+            return vk::DescriptorSetLayoutBinding()
+                .setBinding(Binding)
+                .setDescriptorType(Type)
+                .setDescriptorCount(ArraySize)
+                .setStageFlags(StageFlags);
         }
 
-        vk::DescriptorBufferInfo GetBufferInfo(uint32_t descriptorIndex = 0) const
+        // only one a
+        vk::DeviceAddress GetAccelerationStructure( uint32_t resourceIndex = 0) const
         {
-            return vk::DescriptorBufferInfo()
-                .setBuffer(reinterpret_cast<vk::Buffer*>(pItems)[descriptorIndex]) // index into array of buffers
-                .setOffset(0)
-                .setRange(VK_WHOLE_SIZE);
+            return pAccelerationStructures[resourceIndex];
         }
 
-        vk::DescriptorImageInfo GetImageInfo(uint32_t descriptorIndex = 0, vk::ImageLayout imgLayout = vk::ImageLayout::eGeneral) const
+        vk::DescriptorAddressInfoEXT GetTexelAddressinfo(uint32_t resourceIndex = 0) const
+        {
+            return vk::DescriptorAddressInfoEXT()
+                .setRange(pTexelBuffers[resourceIndex].Buffer.Size)
+                .setFormat(pTexelBuffers[resourceIndex].Format)
+                .setAddress(pTexelBuffers[resourceIndex].Buffer.DevAddress);
+        }
+
+        vk::DescriptorAddressInfoEXT GetAddressInfo(uint32_t resourceIndex = 0) const
+        {
+            auto addressInfo = vk::DescriptorAddressInfoEXT()
+                .setRange(pResources[resourceIndex].Size)
+                .setFormat(vk::Format::eUndefined);
+
+            switch (Type)
+            {
+            case vk::DescriptorType::eUniformBuffer:
+                addressInfo.address = pResources[resourceIndex].DevAddress;
+                break;
+            case vk::DescriptorType::eStorageBuffer:
+                addressInfo.address = pResources[resourceIndex].DevAddress;
+                break;
+            case vk::DescriptorType::eAccelerationStructureKHR:
+                addressInfo.address = pResources[resourceIndex].DevAddress;
+                break;
+            case vk::DescriptorType::eStorageImage:
+                addressInfo.address = pResources[resourceIndex].DevAddress;
+                break;
+            }
+
+            return addressInfo;
+        }
+
+        vk::DescriptorImageInfo GetImageInfo(uint32_t resourceIndex = 0) const
         {
             return vk::DescriptorImageInfo()
-                .setImageLayout(imgLayout)
-                .setImageView(reinterpret_cast<vk::ImageView*>(pItems)[descriptorIndex]); // index into array of image views
+                .setImageView(pImages[resourceIndex].View)
+                .setImageLayout(pImages[resourceIndex].Layout);
         }
 
-        vk::WriteDescriptorSetAccelerationStructureKHR GetAccelerationStructureInfo(uint32_t descriptorIndex = 0, uint32_t count = 1)
+    
+        vk::DescriptorBufferInfo GetBufferInfo(uint32_t resourceIndex = 0) const
         {
-            return vk::WriteDescriptorSetAccelerationStructureKHR()
-                .setAccelerationStructureCount(1) 
-                .setPAccelerationStructures(reinterpret_cast<vk::AccelerationStructureKHR*>(pItems));
+            return vk::DescriptorBufferInfo()
+                .setBuffer(pResources[resourceIndex].Buffer)
+                .setRange(pResources[resourceIndex].Size);
         }
-
-        uint32_t Binding;
-        vk::DescriptorType Type;
-        vk::ShaderStageFlags StageFlags;
-        uint32_t DescriptorCount = 1;
-
-        // pointer to the actual item, eg. a vk::Image, vk::Buffer, etc.
-        // if DescriptorCount > 1, this is a pointer to an array of items
-        void* pItems = nullptr; 
         
-        vk::DescriptorBindingFlagBits mFlags;
-
-        bool DynamicArray = false;
-
-    };
-
-    struct DescriptorSet
-    {
-        DescriptorSet() = default;
-        DescriptorSet(vk::DescriptorSet set, vk::DescriptorSetLayout layout, const std::vector<DescriptorItem>& items)
-            : Set(set), Layout(layout), Items(std::move(items))
-        {
-        }
-
-        // returns a write descriptor set for the given binding
-        // user has to fill the type of descriptor and the actual item
-        vk::WriteDescriptorSet GetWriteDescriptorSets(vk::DescriptorType type , uint32_t binding, uint32_t writeCount = 1, uint32_t writeStartIndex = 0) const
-        {
-            return vk::WriteDescriptorSet()
-                .setDstSet(Set)
-                .setDstBinding(binding)
-                .setDescriptorType(type)
-                .setDescriptorCount(writeCount)
-                .setDstArrayElement(writeStartIndex);
-        }
-
-        vk::DescriptorSet Set;
-        vk::DescriptorSetLayout Layout;
-        std::vector<DescriptorItem> Items;
     };
 
 

--- a/Include/Vulray/VulrayDevice.h
+++ b/Include/Vulray/VulrayDevice.h
@@ -162,10 +162,31 @@ namespace vr
         // 2. the pointers should point to an array of DescriptorItem::count elements
         // 3. If there are n descriptor sets in the buffer, the setIndexInBuffer should be used to specify the nth set to update
         // 4. If there are multiple descriptor sets in the buffer, they MUST have the same layout
+        // mappedData is the pointer to the mapped data of the buffer, if it is null, the buffer will be mapped and unmapped
+
         void UpdateDescriptorBuffer(DescriptorBuffer& buffer,
             const std::vector<DescriptorItem>& items,
             DescriptorBufferType type,
-            uint32_t setIndexInBuffer = 0);
+            uint32_t setIndexInBuffer = 0,
+            void* pMappedData = nullptr);
+
+        // Updates the descriptor buffer with the single descriptor item including all the elements in the array
+        void UpdateDescriptorBuffer(DescriptorBuffer& buffer,
+            const DescriptorItem& item,
+            DescriptorBufferType type,
+            uint32_t setIndexInBuffer = 0,
+            void* pMappedData = nullptr);
+
+        // Updates the descriptor buffer with one element of the descriptor item 
+        // Conditions are the same as the other UpdateDescriptorBuffer function
+        // itemIndex is the index of the descriptor item in the layout, so DescriptorItem::p***[itemIndex] has to be valid
+        // mappedData is the pointer to the mapped data of the buffer, if it is null, the buffer will be mapped and unmapped
+        void UpdateDescriptorBuffer(DescriptorBuffer& buffer,
+            const DescriptorItem& item,
+            uint32_t itemIndex,
+            DescriptorBufferType type,
+            uint32_t setIndexInBuffer = 0,
+            void* pMappedData = nullptr);
 
         // Binds the descriptor buffer to the command buffer
         // returns the buffer indices that were bound

--- a/Source/Descriptors.cpp
+++ b/Source/Descriptors.cpp
@@ -195,6 +195,10 @@ static void GetImageInfoOfDescriptorItem(const vr::DescriptorItem& item,
         *pImageInfo = item.GetImageInfo(resourceIndex);
         pData->pSampledImage = pImageInfo;
         break;
+    case vk::DescriptorType::eStorageImage:
+        *pImageInfo = item.GetImageInfo(resourceIndex);
+        pData->pStorageImage = pImageInfo;
+        break;
     }
 }
 

--- a/Source/Descriptors.cpp
+++ b/Source/Descriptors.cpp
@@ -2,89 +2,135 @@
 #include "Vulray/Shader.h"
 #include "Vulray/Descriptors.h"
 
+// These functions extract the addrss info / image info from the descriptor item
+// and bind it to the corresponding pointer in the  DescriptorDataEXT struct
+// they also return the size of the descriptor item
+static void GetAddressOfDescriptorItem(const vr::DescriptorItem& item,
+    uint32_t resourceIndex,
+    vk::DescriptorAddressInfoEXT* pAddressInfo = nullptr,
+    vk::DescriptorDataEXT* pData = nullptr);
+
+static void GetImageInfoOfDescriptorItem(const vr::DescriptorItem& item,
+    uint32_t resourceIndex,
+    vk::DescriptorImageInfo* pAddressInfo = nullptr,
+    vk::DescriptorDataEXT* pData = nullptr);
+
+static size_t GetDescriptorTypeDataSize(vk::DescriptorType type, const vk::PhysicalDeviceDescriptorBufferPropertiesEXT& bufferProps);
+
+
 namespace vr
 {
-    
-
-    vk::DescriptorSet VulrayDevice::AllocateDescriptorSet(vk::DescriptorPool pool, vk::DescriptorSetLayout layout, uint32_t maxVariableDescriptors)
-    {
-        auto allocInfo = vk::DescriptorSetAllocateInfo()
-            .setDescriptorPool(pool)
-            .setDescriptorSetCount(1)
-            .setPSetLayouts(&layout);
-
-        return mDevice.allocateDescriptorSets(allocInfo)[0]; // return the first set, because we only allocated one
-    }
-
-    void VulrayDevice::UpdateDescriptorSet(const std::vector<vk::WriteDescriptorSet>& writes)
-    {
-        mDevice.updateDescriptorSets(writes, {});
-    }
-    void VulrayDevice::UpdateDescriptorSet(const vk::WriteDescriptorSet& writes)
-    {
-        mDevice.updateDescriptorSets(1, &writes, 0, nullptr);
-    }
 
 
     vk::DescriptorSetLayout VulrayDevice::CreateDescriptorSetLayout(const std::vector<DescriptorItem> &bindings)
     {
-        bool hasDynamic = false;
-        bool hasUpdateAfterBind = false;
         // prepare the layout bindings
         std::vector<vk::DescriptorSetLayoutBinding> layoutBindings;
         layoutBindings.reserve(bindings.size()); 
 
         
         for (auto& binding : bindings)
-        {
             layoutBindings.push_back(binding.GetLayoutBinding());
-            if(binding.DynamicArray)
-                hasDynamic = true;
-            if(binding.mFlags & vk::DescriptorBindingFlagBits::eUpdateAfterBind)
-                hasUpdateAfterBind = true;
-        }
-
-        //if there are dynamic bindings, we need to set the flags
-        //the user is responsible for having the last binding in the set be a dynamic array
-
-        //prepare the flags
-        std::vector<vk::DescriptorBindingFlags> itemFlags;
-        itemFlags.reserve(bindings.size());
-
-        for(auto& binding : bindings)
-        {
-            itemFlags.push_back(binding.mFlags);
-            if(binding.DynamicArray)
-            {
-                itemFlags.back() |= (vk::DescriptorBindingFlagBits::ePartiallyBound |
-                vk::DescriptorBindingFlagBits::eVariableDescriptorCount);
-            }
-        }
-
-        
-
-        auto flags = vk::DescriptorSetLayoutBindingFlagsCreateInfo()
-            .setBindingCount(static_cast<uint32_t>(itemFlags.size()))
-            .setPBindingFlags(itemFlags.data());
 
         return mDevice.createDescriptorSetLayout(vk::DescriptorSetLayoutCreateInfo()
             .setBindingCount(static_cast<uint32_t>(layoutBindings.size()))
-            .setFlags(hasUpdateAfterBind ? vk::DescriptorSetLayoutCreateFlagBits::eUpdateAfterBindPool : vk::DescriptorSetLayoutCreateFlags(0))
-            .setPBindings(layoutBindings.data())
-            .setPNext(&flags));
+            .setFlags(vk::DescriptorSetLayoutCreateFlagBits::eDescriptorBufferEXT)
+            .setPBindings(layoutBindings.data()));
     }
 
-    vk::DescriptorPool VulrayDevice::CreateDescriptorPool(const std::vector<vk::DescriptorPoolSize>& poolSizes, vk::DescriptorPoolCreateFlags flags, uint32_t maxSets)
+    void VulrayDevice::UpdateDescriptorBuffer(DescriptorBuffer& buffer,
+        const std::vector<DescriptorItem>& items,
+        DescriptorBufferType type,
+        uint32_t setIndexInBuffer)
     {
-        return mDevice.createDescriptorPool(vk::DescriptorPoolCreateInfo()
-            .setMaxSets(maxSets)
-            .setFlags(flags)
-            .setPoolSizeCount(static_cast<uint32_t>(poolSizes.size()))
-            .setPPoolSizes(poolSizes.data()));
+        // offset into the buffer
+        uint32_t setOffset = buffer.GetOffsetToSet(setIndexInBuffer);
+
+        auto bindingInfo = vk::DescriptorBufferBindingInfoEXT()
+            .setAddress(buffer.Buffer.DevAddress + setOffset);
+
+        char* mappedData = (char*)MapBuffer(buffer.Buffer) + setOffset;
+        
+        char* cursor = mappedData; // cursor to the current item
+
+        auto descGetInfo = vk::DescriptorGetInfoEXT();
+
+        auto addressInfo = vk::DescriptorAddressInfoEXT(); // in case of buffer
+
+        auto imageInfo = vk::DescriptorImageInfo(); // in case of image or sampler
+
+
+        for (uint32_t i = 0; i < items.size(); i++)
+        {
+            cursor = mappedData + items[i].BindingOffset; // move the cursor to the current item
+
+            descGetInfo.type = items[i].Type; // same type for all items in the array
+            size_t dataSize = GetDescriptorTypeDataSize(items[i].Type, mDescriptorBufferProperties);
+
+            for(uint32_t j = 0; j < items[i].ArraySize; j++)
+            {
+                if(type == DescriptorBufferType::Resource)
+                {
+                    if(items[i].Type == vk::DescriptorType::eStorageImage) // storage images are resources, but they need image info
+                        GetImageInfoOfDescriptorItem(items[i], j, &imageInfo, &descGetInfo.data);
+                    else
+                        GetAddressOfDescriptorItem(items[i], j, &addressInfo, &descGetInfo.data);
+
+                    mDevice.getDescriptorEXT(&descGetInfo, dataSize, cursor, mDynLoader); // write to cursor
+
+                    cursor += dataSize;
+                }
+                else if(type == DescriptorBufferType::Sampler | type == DescriptorBufferType::CombinedImageSampler)
+                {
+                    GetImageInfoOfDescriptorItem(items[i], j, &imageInfo, &descGetInfo.data);
+                    
+                    mDevice.getDescriptorEXT(&descGetInfo, dataSize, cursor, mDynLoader); // write to cursor
+
+                    cursor += dataSize;
+                }
+            }
+        }
+        // we can unmap the buffer now, because we wrote all the data to it
+        UnmapBuffer(buffer.Buffer);
+
     }
 
-    
-    vk::PipelineLayout VulrayDevice::CreatePipelineLayout(const std::vector<vk::DescriptorSetLayout>& descLayouts)
+    std::vector<uint32_t> VulrayDevice::BindDescriptorBuffer(const std::vector<DescriptorBuffer>& buffers, vk::CommandBuffer cmdBuf)
+    {
+        std::vector<vk::DescriptorBufferBindingInfoEXT> bindingInfos;
+        bindingInfos.reserve(buffers.size());
+
+        std::vector<uint32_t> bufferIndices;
+        bufferIndices.reserve(buffers.size());
+        
+
+
+
+        for(int i = 0; i < buffers.size(); i++)
+        {
+            bindingInfos.push_back(vk::DescriptorBufferBindingInfoEXT()
+                .setAddress(buffers[i].Buffer.DevAddress)
+                .setUsage((vk::BufferUsageFlagBits)buffers[i].Type));
+
+            bufferIndices.push_back(i);
+        }
+
+        cmdBuf.bindDescriptorBuffersEXT(bindingInfos, mDynLoader);
+
+        return bufferIndices;
+    }
+
+    void VulrayDevice::BindDescriptorSet(vk::PipelineLayout layout, uint32_t set, uint32_t bufferIndex, vk::DeviceSize offset, vk::CommandBuffer cmdBuf, vk::PipelineBindPoint bindPoint)
+    {
+        cmdBuf.setDescriptorBufferOffsetsEXT(bindPoint, layout, set, 1, &bufferIndex, &offset, mDynLoader);
+    }
+
+    void VulrayDevice::BindDescriptorSet(vk::PipelineLayout layout, uint32_t set, std::vector<uint32_t> bufferIndex, std::vector<vk::DeviceSize> offset, vk::CommandBuffer cmdBuf, vk::PipelineBindPoint bindPoint)
+    {
+        cmdBuf.setDescriptorBufferOffsetsEXT(bindPoint, layout, set, bufferIndex.size(), bufferIndex.data(), offset.data(), mDynLoader);
+    }
+
+    vk::PipelineLayout VulrayDevice::CreatePipelineLayout(const std::vector<vk::DescriptorSetLayout> &descLayouts)
     {
         //create pipeline layout
         return mDevice.createPipelineLayout(vk::PipelineLayoutCreateInfo()
@@ -100,4 +146,79 @@ namespace vr
             .setPSetLayouts(&descLayout));
     }
 
+}
+
+
+static void GetAddressOfDescriptorItem(const vr::DescriptorItem& item,
+    uint32_t resourceIndex,
+    vk::DescriptorAddressInfoEXT* pAddressInfo,
+    vk::DescriptorDataEXT* pData)
+{
+    
+    switch (item.Type)
+    {
+    case vk::DescriptorType::eUniformBuffer:
+        *pAddressInfo = item.GetAddressInfo(resourceIndex);
+        pData->pUniformBuffer = pAddressInfo;
+        break;
+    case vk::DescriptorType::eStorageBuffer:
+        *pAddressInfo = item.GetAddressInfo(resourceIndex);
+        pData->pStorageBuffer = pAddressInfo;
+        break;
+    case vk::DescriptorType::eAccelerationStructureKHR:
+        pData->accelerationStructure = item.GetAccelerationStructure(resourceIndex);
+        break;
+    case vk::DescriptorType::eStorageTexelBuffer:
+        *pAddressInfo = item.GetTexelAddressinfo(resourceIndex);
+        pData->pStorageTexelBuffer = pAddressInfo;
+        break;
+    case vk::DescriptorType::eUniformTexelBuffer:
+        *pAddressInfo = item.GetTexelAddressinfo(resourceIndex);
+        pData->pUniformTexelBuffer = pAddressInfo;
+        break;
+        
+    }
+}
+
+static void GetImageInfoOfDescriptorItem(const vr::DescriptorItem& item,
+    uint32_t resourceIndex,
+    vk::DescriptorImageInfo* pImageInfo,
+    vk::DescriptorDataEXT* pData)
+{
+    switch (item.Type)
+    {
+    case vk::DescriptorType::eCombinedImageSampler:
+        *pImageInfo = item.GetImageInfo(resourceIndex);
+        pData->pCombinedImageSampler = pImageInfo;
+        break;
+    case vk::DescriptorType::eSampledImage:
+        *pImageInfo = item.GetImageInfo(resourceIndex);
+        pData->pSampledImage = pImageInfo;
+        break;
+    }
+}
+
+static size_t GetDescriptorTypeDataSize(vk::DescriptorType type, const vk::PhysicalDeviceDescriptorBufferPropertiesEXT& bufferProps)
+{
+    switch (type)
+    {
+    case vk::DescriptorType::eUniformBuffer:
+        return vr::AlignUp(bufferProps.uniformBufferDescriptorSize, bufferProps.descriptorBufferOffsetAlignment);
+    case vk::DescriptorType::eStorageBuffer:
+        return vr::AlignUp(bufferProps.storageBufferDescriptorSize, bufferProps.descriptorBufferOffsetAlignment);
+    case vk::DescriptorType::eAccelerationStructureKHR:
+        return vr::AlignUp(bufferProps.accelerationStructureDescriptorSize, bufferProps.descriptorBufferOffsetAlignment);
+    case vk::DescriptorType::eStorageTexelBuffer:
+        return vr::AlignUp(bufferProps.storageTexelBufferDescriptorSize, bufferProps.descriptorBufferOffsetAlignment);
+    case vk::DescriptorType::eUniformTexelBuffer:
+        return vr::AlignUp(bufferProps.uniformTexelBufferDescriptorSize, bufferProps.descriptorBufferOffsetAlignment);
+    case vk::DescriptorType::eStorageImage:
+        return vr::AlignUp(bufferProps.storageImageDescriptorSize, bufferProps.descriptorBufferOffsetAlignment);
+    case vk::DescriptorType::eCombinedImageSampler:
+        return vr::AlignUp(bufferProps.combinedImageSamplerDescriptorSize, bufferProps.descriptorBufferOffsetAlignment);
+    case vk::DescriptorType::eSampledImage:
+        return vr::AlignUp(bufferProps.sampledImageDescriptorSize, bufferProps.descriptorBufferOffsetAlignment);
+    default:
+        return 0;
+    }
 }

--- a/Source/RayTracingPipeline.cpp
+++ b/Source/RayTracingPipeline.cpp
@@ -131,7 +131,8 @@ namespace vr
             .setGroupCount(static_cast<uint32_t>(shaderGroups.size()))
             .setPGroups(shaderGroups.data())
             .setMaxPipelineRayRecursionDepth(recursuionDepth) 
-            .setLayout(layout);
+            .setLayout(layout)
+            .setFlags(vk::PipelineCreateFlagBits::eDescriptorBufferEXT);
 
         auto pipeline = mDevice.createRayTracingPipelineKHR(nullptr, nullptr, pipelineInf, nullptr, mDynLoader);
 

--- a/Source/VulkanBuilder.cpp
+++ b/Source/VulkanBuilder.cpp
@@ -22,6 +22,7 @@ namespace vr
         VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
         VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
         VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+        VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME,
         VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME // required by accel struct extension
     };
 
@@ -108,23 +109,15 @@ namespace vr
             .setAccelerationStructure(true)
             .setDescriptorBindingAccelerationStructureUpdateAfterBind(true);
 
+        auto descbufferFeatures = vk::PhysicalDeviceDescriptorBufferFeaturesEXT()
+            .setDescriptorBuffer(true)
+            .setDescriptorBufferImageLayoutIgnored(true);
+
         physSelector.add_required_extension_features(raytracingFeatures);
         physSelector.add_required_extension_features(accelFeatures);
+        physSelector.add_required_extension_features(descbufferFeatures);
 
         PhysicalDeviceFeatures12.bufferDeviceAddress = true;
-        PhysicalDeviceFeatures12.descriptorIndexing = true;
-        PhysicalDeviceFeatures12.runtimeDescriptorArray = true;
-        PhysicalDeviceFeatures12.descriptorBindingPartiallyBound = true;
-        PhysicalDeviceFeatures12.descriptorBindingVariableDescriptorCount = true;
-        PhysicalDeviceFeatures12.shaderSampledImageArrayNonUniformIndexing = true;
-        PhysicalDeviceFeatures12.shaderStorageImageArrayNonUniformIndexing = true;
-        PhysicalDeviceFeatures12.shaderStorageBufferArrayNonUniformIndexing = true;
-        PhysicalDeviceFeatures12.shaderStorageImageArrayNonUniformIndexing = true;
-
-        PhysicalDeviceFeatures12.descriptorBindingStorageImageUpdateAfterBind = true;
-        PhysicalDeviceFeatures12.descriptorBindingStorageBufferUpdateAfterBind = true;
-        PhysicalDeviceFeatures12.descriptorBindingSampledImageUpdateAfterBind = true;
-        PhysicalDeviceFeatures12.descriptorBindingUniformBufferUpdateAfterBind = true;
 
         physSelector.set_required_features(PhysicalDeviceFeatures10);
         physSelector.set_required_features_11(PhysicalDeviceFeatures11);

--- a/Source/VulkanBuilder.cpp
+++ b/Source/VulkanBuilder.cpp
@@ -118,6 +118,17 @@ namespace vr
         physSelector.add_required_extension_features(descbufferFeatures);
 
         PhysicalDeviceFeatures12.bufferDeviceAddress = true;
+        PhysicalDeviceFeatures12.descriptorIndexing = true;
+        PhysicalDeviceFeatures12.descriptorBindingVariableDescriptorCount = true;
+        PhysicalDeviceFeatures12.descriptorBindingPartiallyBound = true;
+        PhysicalDeviceFeatures12.runtimeDescriptorArray = true;
+        
+        PhysicalDeviceFeatures12.shaderSampledImageArrayNonUniformIndexing = true;
+        PhysicalDeviceFeatures12.shaderStorageBufferArrayNonUniformIndexing = true;
+        PhysicalDeviceFeatures12.shaderStorageImageArrayNonUniformIndexing = true;
+        PhysicalDeviceFeatures12.shaderUniformBufferArrayNonUniformIndexing = true;
+        PhysicalDeviceFeatures12.shaderUniformTexelBufferArrayNonUniformIndexing = true;
+        PhysicalDeviceFeatures12.shaderStorageTexelBufferArrayNonUniformIndexing = true;
 
         physSelector.set_required_features(PhysicalDeviceFeatures10);
         physSelector.set_required_features_11(PhysicalDeviceFeatures11);

--- a/Source/VulrayDevice.cpp
+++ b/Source/VulrayDevice.cpp
@@ -25,6 +25,8 @@ namespace vr
         auto deviceProperties = vk::PhysicalDeviceProperties2KHR();
         deviceProperties.pNext = &mRayTracingProperties;
         mRayTracingProperties.pNext = &mAccelProperties;
+        mAccelProperties.pNext = &mDescriptorBufferProperties;
+        mDescriptorBufferProperties.pNext = nullptr;
 
         mPhysicalDevice.getProperties2KHR(&deviceProperties, mDynLoader);
 


### PR DESCRIPTION
Added the extension to enable descriptor buffers, because they are more transparent objects that allow for more control of descriptors. Since this extension is available for nearly every GPU that supports ray tracing, it supported for anyone who uses this library. 