### PR TITLE
Pipeline library

### DIFF
--- a/Include/Vulray/SBT.h
+++ b/Include/Vulray/SBT.h
@@ -93,30 +93,24 @@ namespace vr
     /// @brief Structure that defines the information needed to create a shader binding table
     struct ShaderBindingTableInfo
     {
-        /// @brief How many ray gen shaders are in the shader binding table
-        uint32_t RayGenShaderCount = 0;
         /// @brief The size of each ray gen shader record in bytes
         uint32_t RayGenShaderRecordSize = 0;
 
-        /// @brief How many miss shaders are in the shader binding table
-        uint32_t MissShaderCount = 0;
         /// @brief The size of each miss shader record in bytes
         uint32_t MissShaderRecordSize = 0;
 
-        /// @brief How many hit groups are in the shader binding table
-        uint32_t HitGroupCount = 0;
         /// @brief The size of each hit group shader record in bytes
         uint32_t HitGroupRecordSize = 0;
 
-        /// @brief How many callable shaders are in the shader binding table
-        uint32_t CallableShaderCount = 0;
         /// @brief The size of each callable shader record in bytes
         uint32_t CallableShaderRecordSize = 0;
 
 
-        /// Graph of how the shaders might be mixed in a Full Pipeline
+        /// Graph of how the shaders might be mixed in a full pipeline.
         /// The shaders can be mixed in any way, but this is just an example
+
         /// | Pipeline                      | SBT Index |
+        /// ---------------------------------------------
         /// | ShaderCollection1.Rgen        | 0         |
         /// | ShaderCollection1.Miss        | 1         |
         /// | ShaderCollection1.HitGroup    | 2         |
@@ -126,9 +120,14 @@ namespace vr
         /// | ShaderCollection2.HitGroup2   | 6         |
         /// | ShaderCollection2.Callable    | 7         |
         /// | ShaderCollection3.Rgen        | 8         |
-        /// These shaders must be organised per shader type
-        /// That would turn the graph into this
+        /// ---------------------------------------------
+        /// We want to support linking new shader collections to the already existing pipeline for efficiency.
+        /// This means that the shaders can be mixed in any way and organising them is necessary for the SBT to work.
+        /// We need indices for shader types to tell where in the pipeline the shaders live.
+        /// Then the shaders go into the SBT organised by their index.
+        /// That would turn the graph into this.
         /// | Pipeline                      | SBT Index |
+        /// ---------------------------------------------
         /// | ShaderCollection1.Rgen        | 0         |
         /// | ShaderCollection3.Rgen        | 1         |
         /// | ShaderCollection1.Miss        | 2         | 
@@ -138,6 +137,8 @@ namespace vr
         /// | ShaderCollection2.HitGroup2   | 6         |
         /// | ShaderCollection1.Callable    | 7         |
         /// | ShaderCollection2.Callable    | 8         |
+        /// ---------------------------------------------
+
 
 
         /// @brief These vectors contain where the raygen shaders live in the pipeline
@@ -151,7 +152,6 @@ namespace vr
 
         /// @brief These vectors where the callable shaders live in the pipeline
         std::vector<uint32_t> CallableIndices = {};
-
     };
 
 }

--- a/Include/Vulray/SBT.h
+++ b/Include/Vulray/SBT.h
@@ -63,17 +63,6 @@ namespace vr
         /// | CallableShaders  |
     };
 
-    /// @brief Contains all the shaders that will be used in a shader binding table and the shader record size for each shader type
-    /// This structure is used to build the SBTBuffer and the pipeline
-    struct ShaderBindingTable
-    {
-        RayTracingShaderCollection Shaders = {};
-        uint32_t RayGenShaderRecordSize     = 0; //size of each ray gen shader record
-        uint32_t MissShaderRecordSize       = 0; //size of each miss shader record
-        uint32_t HitShaderRecordSize        = 0; //size of each hit group shader record
-        uint32_t CallableShaderRecordSize   = 0; //size of each callable shader record
-    };
-
     /// @brief Structure that defines the settings for a ray tracing pipeline. When creating pipeline libraries that 
     ///  link to a single pipeline, the settigns should be the same for all pipelines
     struct PipelineSettings

--- a/Include/Vulray/SBT.h
+++ b/Include/Vulray/SBT.h
@@ -14,19 +14,19 @@ namespace vr
     /// @brief Contains all shaders that will be used in a hit group of an SBT
     struct HitGroup
     {
-        Shader ClosestHitShader;
-        Shader AnyHitShader;
-        Shader IntersectionShader;
+        Shader ClosestHitShader     = {};
+        Shader AnyHitShader         = {};
+        Shader IntersectionShader   = {};
         
     };
 
     /// @brief Structure that defines a Shader Binding Table that can be used to trace rays
     struct SBTBuffer
     {
-        AllocatedBuffer RayGenBuffer;
-        AllocatedBuffer MissBuffer;
-        AllocatedBuffer HitGroupBuffer;
-        AllocatedBuffer CallableBuffer;
+        AllocatedBuffer RayGenBuffer    = {};
+        AllocatedBuffer MissBuffer      = {};
+        AllocatedBuffer HitGroupBuffer  = {};
+        AllocatedBuffer CallableBuffer  = {};
 
 
         /* 
@@ -34,10 +34,10 @@ namespace vr
         Next shader record is at offset + ShaderBindingTable::{ShaderType}GroupSize
         */
 
-        vk::StridedDeviceAddressRegionKHR RayGenRegion = {};
-        vk::StridedDeviceAddressRegionKHR MissRegion = {};
-        vk::StridedDeviceAddressRegionKHR HitGroupRegion = {};
-        vk::StridedDeviceAddressRegionKHR CallableRegion = {};
+        vk::StridedDeviceAddressRegionKHR RayGenRegion      = {};
+        vk::StridedDeviceAddressRegionKHR MissRegion        = {};
+        vk::StridedDeviceAddressRegionKHR HitGroupRegion    = {};
+        vk::StridedDeviceAddressRegionKHR CallableRegion    = {};
     };
 
 
@@ -53,6 +53,14 @@ namespace vr
         /// Filled by Vulray when creating the pipeline library.
         /// @note Doesn't need to be destroyed, because it is destroyed when the pipeline it is linked to is destroyed
         vk::Pipeline CollectionPipeline = nullptr;
+
+        /// The order of how the shaders in the pipeline are laid out in the pipeline library.
+        /// If there are no shaders of a certain type, the next shader type will be laid out where it would have been.
+        /// So if no miss shaders are present, the hit groups will be after the ray gen shaders.
+        /// | RayGenShaders    |
+        /// | MissShaders      |
+        /// | HitGroups        |
+        /// | CallableShaders  |
     };
 
     /// @brief Contains all the shaders that will be used in a shader binding table and the shader record size for each shader type
@@ -60,10 +68,10 @@ namespace vr
     struct ShaderBindingTable
     {
         RayTracingShaderCollection Shaders = {};
-        uint32_t RayGenShaderRecordSize = 0; //size of each ray gen shader record
-        uint32_t MissShaderRecordSize = 0; //size of each miss shader record
-        uint32_t HitShaderRecordSize = 0; //size of each hit group shader record
-        uint32_t CallableShaderRecordSize = 0; //size of each callable shader record
+        uint32_t RayGenShaderRecordSize     = 0; //size of each ray gen shader record
+        uint32_t MissShaderRecordSize       = 0; //size of each miss shader record
+        uint32_t HitShaderRecordSize        = 0; //size of each hit group shader record
+        uint32_t CallableShaderRecordSize   = 0; //size of each callable shader record
     };
 
     /// @brief Structure that defines the settings for a ray tracing pipeline. When creating pipeline libraries that 
@@ -104,6 +112,46 @@ namespace vr
         uint32_t CallableShaderCount = 0;
         /// @brief The size of each callable shader record in bytes
         uint32_t CallableShaderRecordSize = 0;
+
+
+        /// Graph of how the shaders might be mixed in a Full Pipeline
+        /// The shaders can be mixed in any way, but this is just an example
+        /// | Pipeline                      | SBT Index |
+        /// | ShaderCollection1.Rgen        | 0         |
+        /// | ShaderCollection1.Miss        | 1         |
+        /// | ShaderCollection1.HitGroup    | 2         |
+        /// | ShaderCollection1.Callable    | 3         |
+        /// | ShaderCollection2.Miss        | 4         |
+        /// | ShaderCollection2.HitGroup1   | 5         |
+        /// | ShaderCollection2.HitGroup2   | 6         |
+        /// | ShaderCollection2.Callable    | 7         |
+        /// | ShaderCollection3.Rgen        | 8         |
+        /// These shaders must be organised per shader type
+        /// That would turn the graph into this
+        /// | Pipeline                      | SBT Index |
+        /// | ShaderCollection1.Rgen        | 0         |
+        /// | ShaderCollection3.Rgen        | 1         |
+        /// | ShaderCollection1.Miss        | 2         | 
+        /// | ShaderCollection2.Miss        | 3         |
+        /// | ShaderCollection1.HitGroup    | 4         |
+        /// | ShaderCollection2.HitGroup1   | 5         |
+        /// | ShaderCollection2.HitGroup2   | 6         |
+        /// | ShaderCollection1.Callable    | 7         |
+        /// | ShaderCollection2.Callable    | 8         |
+
+
+        /// @brief These vectors contain where the raygen shaders live in the pipeline
+        std::vector<uint32_t> RayGenIndices = {};
+
+        /// @brief These vectors where the miss shaders live in the pipeline
+        std::vector<uint32_t> MissIndices = {};
+
+        /// @brief These vectors where the hit group shaders live in the pipeline
+        std::vector<uint32_t> HitGroupIndices = {};
+
+        /// @brief These vectors where the callable shaders live in the pipeline
+        std::vector<uint32_t> CallableIndices = {};
+
     };
 
 }

--- a/Include/Vulray/SBT.h
+++ b/Include/Vulray/SBT.h
@@ -2,6 +2,15 @@
 
 namespace vr
 {
+    /// @brief Enum that defines the type of shader in the shader binding table
+    enum class ShaderGroup : uint8_t
+    {
+        RayGen = 0,
+        Miss = 1,
+        HitGroup = 2,
+        Callable = 3
+    };
+
     /// @brief Contains all shaders that will be used in a hit group of an SBT
     struct HitGroup
     {
@@ -24,32 +33,77 @@ namespace vr
         Offsets define the start of the shader records in bytes. 
         Next shader record is at offset + ShaderBindingTable::{ShaderType}GroupSize
         */
+
         vk::StridedDeviceAddressRegionKHR RayGenRegion = {};
         vk::StridedDeviceAddressRegionKHR MissRegion = {};
         vk::StridedDeviceAddressRegionKHR HitGroupRegion = {};
         vk::StridedDeviceAddressRegionKHR CallableRegion = {};
     };
 
+
+    /// @brief Pipeline library input structure
+    struct RayTracingShaderCollection
+    {
+        std::vector<Shader> RayGenShaders   = {};
+        std::vector<Shader> MissShaders     = {};
+        std::vector<HitGroup> HitGroups     = {};
+        std::vector<Shader> CallableShaders = {};
+
+        /// @brief Pipeline library that contains all the shaders in the collection
+        /// Filled by Vulray when creating the pipeline library.
+        /// @note Doesn't need to be destroyed, because it is destroyed when the pipeline it is linked to is destroyed
+        vk::Pipeline CollectionPipeline = nullptr;
+    };
+
     /// @brief Contains all the shaders that will be used in a shader binding table and the shader record size for each shader type
     /// This structure is used to build the SBTBuffer and the pipeline
     struct ShaderBindingTable
     {
-        Shader RayGenShader;
+        RayTracingShaderCollection Shaders = {};
         uint32_t RayGenShaderRecordSize = 0; //size of each ray gen shader record
-        std::vector<Shader> MissShaders;
         uint32_t MissShaderRecordSize = 0; //size of each miss shader record
-        std::vector<HitGroup> HitGroups;
         uint32_t HitShaderRecordSize = 0; //size of each hit group shader record
-        std::vector<Shader> CallableShaders;
         uint32_t CallableShaderRecordSize = 0; //size of each callable shader record
     };
 
-    /// @brief Enum that defines the type of shader in the shader binding table
-    enum class ShaderGroup : uint8_t
+    /// @brief Structure that defines the settings for a ray tracing pipeline. When creating pipeline libraries that 
+    ///  link to a single pipeline, the settigns should be the same for all pipelines
+    struct PipelineSettings
     {
-        RayGen = 0,
-        Miss = 1,
-        HitGroup = 2,
-        Callable = 3
+        vk::PipelineLayout PipelineLayout;
+
+        /// @brief The maximum number of levels of recursion allowed in the pipeline
+        uint32_t MaxRecursionDepth = 1;
+
+        /// @brief The maximum size of the payload in bytes
+        uint32_t MaxPayloadSize = 0;
+
+        /// @brief The maximum size of the hit attribute in bytes in HitGroups
+        uint32_t MaxHitAttributeSize = 0;
     };
+
+    /// @brief Structure that defines the information needed to create a shader binding table
+    struct ShaderBindingTableInfo
+    {
+        /// @brief How many ray gen shaders are in the shader binding table
+        uint32_t RayGenShaderCount = 0;
+        /// @brief The size of each ray gen shader record in bytes
+        uint32_t RayGenShaderRecordSize = 0;
+
+        /// @brief How many miss shaders are in the shader binding table
+        uint32_t MissShaderCount = 0;
+        /// @brief The size of each miss shader record in bytes
+        uint32_t MissShaderRecordSize = 0;
+
+        /// @brief How many hit groups are in the shader binding table
+        uint32_t HitGroupCount = 0;
+        /// @brief The size of each hit group shader record in bytes
+        uint32_t HitGroupRecordSize = 0;
+
+        /// @brief How many callable shaders are in the shader binding table
+        uint32_t CallableShaderCount = 0;
+        /// @brief The size of each callable shader record in bytes
+        uint32_t CallableShaderRecordSize = 0;
+    };
+
 }

--- a/Include/Vulray/VulrayDevice.h
+++ b/Include/Vulray/VulrayDevice.h
@@ -455,10 +455,17 @@ namespace vr
         /// @brief Gets the opaque handles for the shader records in the SBT buffer
         /// @param pipeline The pipeline that will be used to get the handles
         /// @param firstGroup The index of the first shader group in the pipeline
-        /// @param groupCount The number of shader groups that will be used to get the handles
+        /// @param groupCount The number of shader groups after firstGroup that will be used to get the handles
         /// @return The opaque handles for the shader records in the SBT buffer
         /// @note For Vulray's internal use, but can be used by the user doing custom SBT 
         [[nodiscard]] std::vector<uint8_t> GetHandlesForSBTBuffer(vk::Pipeline pipeline, uint32_t firstGroup, uint32_t groupCount);
+
+        /// @brief Gets the opaque handles for the shader records in the SBT buffer
+        /// @param pipeline The pipeline that will be used to get the handles
+        /// @param firstGroup The index of the first shader group in the pipeline
+        /// @param groupCount The number of shader groups after @c firstGroup that will be used to get the handles
+
+        void GetHandlesForSBTBuffer(vk::Pipeline pipeline, uint32_t firstGroup, uint32_t groupCount, void* data);
 
         /// @brief Writes data to a shader record in the SBT buffer
         /// @param sbtBuf The SBT buffer that will be written to

--- a/Include/Vulray/VulrayDevice.h
+++ b/Include/Vulray/VulrayDevice.h
@@ -39,6 +39,9 @@ namespace vr
         /// @brief Get the Vulkan instance handle
         vk::Instance GetInstance() const { return mInstance; }
 
+        /// @brief Get the Vulkan dynamic loader
+        vk::DispatchLoaderDynamic GetDynamicLoader() const { return mDynLoader; }
+
         /// @brief Get the Physical device properties
         vk::PhysicalDeviceProperties GetProperties() const { return mDeviceProperties; }
 
@@ -323,7 +326,7 @@ namespace vr
         /// @param info The ShaderBindingTable including the collection of shaders that will be used to create the shader stages and shader groups
         /// @return The shader stages and shader groups that are constructed from the ShaderBindingTable
         [[nodiscard]] std::pair<std::vector<vk::PipelineShaderStageCreateInfo>, std::vector<vk::RayTracingShaderGroupCreateInfoKHR>> 
-            GetShaderStagesAndRayTracingGroups(const ShaderBindingTable& info);
+            GetShaderStagesAndRayTracingGroups(const RayTracingShaderCollection& info);
 
         /// @brief Creates a pipeline
         /// @param descLayouts The descriptor set layouts that will be used to create the pipeline layout
@@ -331,7 +334,18 @@ namespace vr
         /// @param recursionDepth The recursion depth of the ray tracing pipeline
         /// @param flags The flags that will be used to create the pipeline. If using Vulray's descriptor buffer, this should have the eDescriptorBufferEXT flag.
         /// @return The created pipeline
-        [[nodiscard]] vk::Pipeline CreateRayTracingPipeline(vk::PipelineLayout layout, const ShaderBindingTable& info, uint32_t recursuionDepth, vk::PipelineCreateFlags flags = vk::PipelineCreateFlagBits::eDescriptorBufferEXT );
+        [[nodiscard]] vk::Pipeline CreateRayTracingPipeline(vk::PipelineLayout layout, const ShaderBindingTable& info, uint32_t recursuionDepth, vk::PipelineCreateFlags flags = vk::PipelineCreateFlagBits::eDescriptorBufferEXT);
+
+        [[nodiscard]] std::pair<vk::Pipeline, ShaderBindingTableInfo> CreateRayTracingPipeline(
+            const std::vector<RayTracingShaderCollection>& shaderCollections,
+            PipelineSettings& settings,
+            vk::PipelineCreateFlags flags = vk::PipelineCreateFlagBits::eDescriptorBufferEXT,
+            vk::DeferredOperationKHR deferredOp = nullptr);
+
+        [[nodiscard]] void CreatePipelineLibrary(RayTracingShaderCollection& shaderCollection, 
+            PipelineSettings& settings,
+            vk::PipelineCreateFlags flags = vk::PipelineCreateFlagBits::eDescriptorBufferEXT,
+            vk::DeferredOperationKHR deferredOp = nullptr);
 
         /// @brief Destroys the shader module
         /// @param shader The shader module that will be destroyed
@@ -461,7 +475,7 @@ namespace vr
         /// @param pipeline The pipeline that will be used to create the SBT buffer
         /// @param sbt The collection of shaders that will be used to create the SBT buffer
         /// @return The created SBT buffer
-        [[nodiscard]] SBTBuffer CreateSBT(vk::Pipeline pipeline, const ShaderBindingTable& sbt);
+        [[nodiscard]] SBTBuffer CreateSBT(vk::Pipeline pipeline, const ShaderBindingTableInfo& sbt);
 
         /// @brief Destroys the SBT buffer
         /// @param buffer The SBT buffer that will be destroyed

--- a/Include/Vulray/VulrayDevice.h
+++ b/Include/Vulray/VulrayDevice.h
@@ -508,10 +508,11 @@ namespace vr
         void WriteToSBT(SBTBuffer sbtBuf, ShaderGroup group, uint32_t groupIndex, void* data, uint32_t dataSize, void* mappedData = nullptr);
 
 
-        /// @brief Creates a buffer for each shader group in the pipeline and copies the opaque handles to the buffer
+        /// @brief Creates a buffer for each shader type in the shader binding table
         /// @param pipeline The pipeline that will be used to create the SBT buffer
-        /// @param sbt The collection of shaders that will be used to create the SBT buffer
-        /// @return The created SBT buffer
+        /// @param sbt The information about the shader binding table, must contain the indices of the shader groups in the pipeline
+        /// @return The SBT buffer object, which has buffers and vk::StridedDeviceAddressRegionKHR for each shader type in the shader binding table
+        /// ready to be used in dispatching rays.
         [[nodiscard]] SBTBuffer CreateSBT(vk::Pipeline pipeline, const ShaderBindingTableInfo& sbt);
 
         /// @brief Destroys the SBT buffer

--- a/Include/Vulray/VulrayDevice.h
+++ b/Include/Vulray/VulrayDevice.h
@@ -328,28 +328,58 @@ namespace vr
         [[nodiscard]] std::pair<std::vector<vk::PipelineShaderStageCreateInfo>, std::vector<vk::RayTracingShaderGroupCreateInfoKHR>> 
             GetShaderStagesAndRayTracingGroups(const RayTracingShaderCollection& info);
 
-        /// @brief Creates a pipeline
-        /// @param descLayouts The descriptor set layouts that will be used to create the pipeline layout
-        /// @param info The ShaderBindingTable that will be used to create the pipeline layout
-        /// @param recursionDepth The recursion depth of the ray tracing pipeline
-        /// @param flags The flags that will be used to create the pipeline. If using Vulray's descriptor buffer, this should have the eDescriptorBufferEXT flag.
-        /// @return The created pipeline
-        [[nodiscard]] vk::Pipeline CreateRayTracingPipeline(vk::PipelineLayout layout, const ShaderBindingTable& info, uint32_t recursuionDepth, vk::PipelineCreateFlags flags = vk::PipelineCreateFlagBits::eDescriptorBufferEXT);
+        /// @brief Creates a ray tracing pipeline
+        /// @param shaderCollection The shader collection that will be used to create the pipeline.
+        /// The field shaderCollection::CollectionPipeline is not used, because it is not linking
+        /// many pipelines together, it is just creating one pipeline.
+        /// @param settings The settings that will be used to create the pipeline
+        /// @param flags The flags that will be used to create the pipeline, default is eDescriptorBufferEXT
+        /// @param deferredOp The deferred operation that will be used to create the pipeline, default is nullptr
+        /// @return The created ray tracing pipeline and the shader binding table info to create the shader binding table
+        [[nodiscard]] std::pair<vk::Pipeline, ShaderBindingTableInfo> CreateRayTracingPipeline(
+            const RayTracingShaderCollection& shaderCollection,
+            PipelineSettings& settings,
+            vk::PipelineCreateFlags flags = vk::PipelineCreateFlagBits::eDescriptorBufferEXT,
+            vk::DeferredOperationKHR deferredOp = nullptr);
 
+        /// @brief Creates a ray tracing pipeline
+        /// @param shaderCollections The shader collections that will be used to create the pipeline.
+        /// The field shaderCollection::CollectionPipeline must be set, because it is linking many pipelines together. 
+        /// @param settings The settings that will be used to create the pipeline. All the pipelines in the shaderCollections
+        /// must have been created with the same settings.
+        /// @param flags The flags that will be used to create the pipeline, default is eDescriptorBufferEXT
+        /// @param deferredOp The deferred operation that will be used to create the pipeline, default is nullptr
+        /// @return The created ray tracing pipeline and the shader binding table info to create the shader binding table
         [[nodiscard]] std::pair<vk::Pipeline, ShaderBindingTableInfo> CreateRayTracingPipeline(
             const std::vector<RayTracingShaderCollection>& shaderCollections,
             PipelineSettings& settings,
             vk::PipelineCreateFlags flags = vk::PipelineCreateFlagBits::eDescriptorBufferEXT,
             vk::DeferredOperationKHR deferredOp = nullptr);
 
-        [[nodiscard]] void CreatePipelineLibrary(RayTracingShaderCollection& shaderCollection, 
+        /// @todo If an issue to anyone, then add support for creation of pipelines even when shaders are destroyed.
+        /// in theory this is already possible, because we don't use the modules for anything other than pipeline library
+        /// creation and we just need to know how many shaders per shader type were in the pipeline library.
+        /// But the if someone doesn't like the fact that std::vector<Shader> is used because it consumes 
+        /// unnecessary memory, then this we can add support for this by adding a new struct that contains
+        /// the number of shaders that were in the pipeline library and the pipeline library handle.
+        /// Should be simple to implement, but I don't see a reason to do it unless someone requests it.
+
+
+        /// @brief Creates a ray tracing pipeline library
+        /// @param shaderCollection The shader collection that will be used to create the pipeline library
+        /// @param settings The settings that will be used to create the pipeline library
+        /// @param flags The flags that will be used to create the pipeline library, default is eDescriptorBufferEXT
+        /// @param deferredOp The deferred operation that will be used to create the pipeline library, default is nullptr
+        /// @return shaderCollection::CollectionPipeline is set to the created pipeline library
+        [[nodiscard]]
+        void CreatePipelineLibrary(RayTracingShaderCollection& shaderCollection, 
             PipelineSettings& settings,
             vk::PipelineCreateFlags flags = vk::PipelineCreateFlagBits::eDescriptorBufferEXT,
             vk::DeferredOperationKHR deferredOp = nullptr);
 
         /// @brief Destroys the shader module
         /// @param shader The shader module that will be destroyed
-        void DestroyShader(Shader & shader);
+        void DestroyShader(Shader& shader);
 
         // @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
         // @@@@@@@@@@@@@@@@@@@@@@@@@ Descriptor Functions @@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/Source/RayTracingPipeline.cpp
+++ b/Source/RayTracingPipeline.cpp
@@ -1,12 +1,11 @@
 #include "Vulray/VulrayDevice.h"
 #include "Vulray/Shader.h"
 
-
 namespace vr
 {
 
     std::pair<std::vector<vk::PipelineShaderStageCreateInfo>, std::vector<vk::RayTracingShaderGroupCreateInfoKHR>> 
-        VulrayDevice::GetShaderStagesAndRayTracingGroups(const ShaderBindingTable& info)
+        VulrayDevice::GetShaderStagesAndRayTracingGroups(const RayTracingShaderCollection& info)
     {
         std::vector<vk::PipelineShaderStageCreateInfo> shaderStages;
         std::vector<vk::RayTracingShaderGroupCreateInfoKHR> shaderGroups;
@@ -14,11 +13,12 @@ namespace vr
         shaderGroups.reserve(1 + info.MissShaders.size() + info.HitGroups.size() + info.CallableShaders.size());
         
         //create ray gen shader groups
+        for(auto& shader : info.RayGenShaders)
         {
             shaderStages.push_back(vk::PipelineShaderStageCreateInfo()
                 .setStage(vk::ShaderStageFlagBits::eRaygenKHR)
-                .setModule(info.RayGenShader.Module)
-                .setPName(info.RayGenShader.EntryPoint));
+                .setModule(shader.Module)
+                .setPName(shader.EntryPoint));
             
             uint32_t rayGenIndex = static_cast<uint32_t>(shaderStages.size() - 1);
 
@@ -124,7 +124,7 @@ namespace vr
 
     vk::Pipeline VulrayDevice::CreateRayTracingPipeline(vk::PipelineLayout layout, const ShaderBindingTable &info, uint32_t recursuionDepth, vk::PipelineCreateFlags flags)
     {
-        auto [shaderStages, shaderGroups] = GetShaderStagesAndRayTracingGroups(info);
+        auto [shaderStages, shaderGroups] = GetShaderStagesAndRayTracingGroups(info.Shaders);
 
         if(recursuionDepth >= mRayTracingProperties.maxRayRecursionDepth)
         {
@@ -152,8 +152,86 @@ namespace vr
         
         return pipeline.value;       
     }
+    std::pair<vk::Pipeline, ShaderBindingTableInfo> VulrayDevice::CreateRayTracingPipeline(
+            const std::vector<RayTracingShaderCollection>& shaderCollections,
+            PipelineSettings& settings,
+            vk::PipelineCreateFlags flags,
+            vk::DeferredOperationKHR deferredOp)
+    {
+        vr::ShaderBindingTableInfo sbtInfo;
 
-    void VulrayDevice::DispatchRays(vk::CommandBuffer cmdBuf, const vk::Pipeline rtPipeline, const SBTBuffer& buffer, uint32_t width, uint32_t height, uint32_t depth)
+        std::vector<vk::Pipeline> libPipelines = {};
+        libPipelines.reserve(shaderCollections.size());
+
+        for(auto& collection : shaderCollections)
+        {
+            libPipelines.push_back(collection.CollectionPipeline);
+            sbtInfo.RayGenShaderCount += collection.RayGenShaders.size();
+            sbtInfo.MissShaderCount += collection.MissShaders.size();
+            sbtInfo.HitGroupCount += collection.HitGroups.size();
+            sbtInfo.CallableShaderCount += collection.CallableShaders.size();
+        }
+        
+        vk::RayTracingPipelineInterfaceCreateInfoKHR interfaceInfo = vk::RayTracingPipelineInterfaceCreateInfoKHR()
+            .setMaxPipelineRayHitAttributeSize(settings.MaxHitAttributeSize)
+            .setMaxPipelineRayPayloadSize(settings.MaxPayloadSize);
+
+        vk::PipelineLibraryCreateInfoKHR libraryInfo = vk::PipelineLibraryCreateInfoKHR()
+            .setPLibraries(libPipelines.data())
+            .setLibraryCount(libPipelines.size());
+
+        auto pipeLine = vk::RayTracingPipelineCreateInfoKHR()
+            .setFlags(flags)
+            .setMaxPipelineRayRecursionDepth(settings.MaxRecursionDepth)
+            .setPLibraryInterface(&interfaceInfo)
+            .setPLibraryInfo(&libraryInfo)
+            .setLayout(settings.PipelineLayout);
+
+        auto res = mDevice.createRayTracingPipelineKHR(deferredOp, nullptr, pipeLine, nullptr, mDynLoader);
+
+        // when deferredOp is not null, the pipeline is created asynchronously, so it doesn't return success or failure
+        if(res.result != vk::Result::eSuccess && res.result != vk::Result::eOperationDeferredKHR) 
+        {
+            VULRAY_LOG_ERROR("CreateRayTracingPipeline: Failed to create ray tracing pipeline");    
+            res.value = nullptr;
+        }
+
+
+        return std::make_pair(res.value, sbtInfo);
+    }
+
+    void VulrayDevice::CreatePipelineLibrary(RayTracingShaderCollection& shaderCollection, 
+            PipelineSettings& settings,
+            vk::PipelineCreateFlags flags,
+            vk::DeferredOperationKHR deferredOp)
+    {
+        vk::RayTracingPipelineInterfaceCreateInfoKHR interfaceInfo = vk::RayTracingPipelineInterfaceCreateInfoKHR()
+            .setMaxPipelineRayHitAttributeSize(settings.MaxHitAttributeSize)
+            .setMaxPipelineRayPayloadSize(settings.MaxPayloadSize);
+
+        auto [shaderStages, shderGroups] = GetShaderStagesAndRayTracingGroups(shaderCollection);
+
+        auto pipeLine = vk::RayTracingPipelineCreateInfoKHR()
+            .setFlags(flags | vk::PipelineCreateFlagBits::eLibraryKHR)
+            .setMaxPipelineRayRecursionDepth(settings.MaxRecursionDepth)
+            .setPLibraryInterface(&interfaceInfo)
+            .setLayout(settings.PipelineLayout)
+            .setGroups(shderGroups)
+            .setStages(shaderStages);
+
+        auto res = mDevice.createRayTracingPipelineKHR(deferredOp, nullptr, pipeLine, nullptr, mDynLoader);
+
+        // when deferredOp is not null, the pipeline is created asynchronously, so it doesn't return success or failure
+        if(res.result != vk::Result::eSuccess && res.result != vk::Result::eOperationDeferredKHR) 
+        {
+            VULRAY_LOG_ERROR("CreateRayTracingPipeline: Failed to create ray tracing pipeline");    
+            res.value = nullptr;
+        }
+
+        shaderCollection.CollectionPipeline = res.value;
+    }
+    
+    void VulrayDevice::DispatchRays(vk::CommandBuffer cmdBuf, const vk::Pipeline rtPipeline, const SBTBuffer &buffer, uint32_t width, uint32_t height, uint32_t depth)
     {
         //dispatch rays
         cmdBuf.bindPipeline(vk::PipelineBindPoint::eRayTracingKHR, rtPipeline);

--- a/Source/RayTracingPipeline.cpp
+++ b/Source/RayTracingPipeline.cpp
@@ -163,13 +163,21 @@ namespace vr
         std::vector<vk::Pipeline> libPipelines = {};
         libPipelines.reserve(shaderCollections.size());
 
+        uint32_t pipelineIndex = 0; // index of shader in the compiled pipeline
+
         for(auto& collection : shaderCollections)
         {
             libPipelines.push_back(collection.CollectionPipeline);
-            sbtInfo.RayGenShaderCount += collection.RayGenShaders.size();
-            sbtInfo.MissShaderCount += collection.MissShaders.size();
-            sbtInfo.HitGroupCount += collection.HitGroups.size();
-            sbtInfo.CallableShaderCount += collection.CallableShaders.size();
+            // Assign where in the pipeline the shaders are, for future SBT creation, 
+            // so opaque handles can be queried for the shader groups
+            for(auto& shader : collection.RayGenShaders)
+                sbtInfo.RayGenIndices.push_back(pipelineIndex++);
+            for(auto& shader : collection.MissShaders)
+                sbtInfo.MissIndices.push_back(pipelineIndex++);
+            for(auto& shader : collection.HitGroups)
+                sbtInfo.HitGroupIndices.push_back(pipelineIndex++);
+            for(auto& shader : collection.CallableShaders)
+                sbtInfo.CallableIndices.push_back(pipelineIndex++);
         }
         
         vk::RayTracingPipelineInterfaceCreateInfoKHR interfaceInfo = vk::RayTracingPipelineInterfaceCreateInfoKHR()

--- a/Source/SBT.cpp
+++ b/Source/SBT.cpp
@@ -110,11 +110,7 @@ namespace vr
             outSBT.CallableBuffer = CreateBuffer(callSize * callCount, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT,
                 vk::BufferUsageFlagBits::eShaderDeviceAddressKHR | vk::BufferUsageFlagBits::eShaderBindingTableKHR, mRayTracingProperties.shaderGroupBaseAlignment);
         
-        //map all the buffers
-
-
         // fill in offsets for all shader groups
-
         if(rgenCount > 0)
             outSBT.RayGenRegion = vk::StridedDeviceAddressRegionKHR()
                 .setDeviceAddress(outSBT.RayGenBuffer.DevAddress)
@@ -183,10 +179,6 @@ namespace vr
         if(callData)
             UnmapBuffer(outSBT.CallableBuffer);
         
-        
-
-
-
         return outSBT;
     }
 

--- a/Source/SBT.cpp
+++ b/Source/SBT.cpp
@@ -137,16 +137,16 @@ namespace vr
                 .setSize(callSize * callCount);
 
 
-        uint8_t* opaqueHandle = new uint8_t[mRayTracingProperties.shaderGroupHandleSize];
-        
+        const uint32_t opaqueHandleSize = mRayTracingProperties.shaderGroupHandleSize;
+        uint8_t* opaqueHandle = new uint8_t[opaqueHandleSize];
         //copy records and shader handles into the SBT buffer
-        void* rgenData = MapBuffer(outSBT.RayGenBuffer);
+        uint8_t* rgenData = rgenSize > 0 ? (uint8_t*)MapBuffer(outSBT.RayGenBuffer) : nullptr;
         for(uint32_t i = 0; rgenData && i < rgenCount; i++)
         {
             uint32_t shaderIndex = sbt.RayGenIndices[i];
             GetHandlesForSBTBuffer(pipeline, shaderIndex, 1, opaqueHandle);
             //copy shader handle
-            memcpy(rgenData, opaqueHandle, mRayTracingProperties.shaderGroupHandleSize);
+            memcpy(rgenData + (i * rgenSize), opaqueHandle, opaqueHandleSize);
         }
         uint8_t* missData = missSize > 0 ? (uint8_t*)MapBuffer(outSBT.MissBuffer) : nullptr;
         for(uint32_t i = 0; missData && i < missCount; i++)
@@ -154,7 +154,7 @@ namespace vr
             uint32_t shaderIndex = sbt.MissIndices[i];
             GetHandlesForSBTBuffer(pipeline, shaderIndex, 1, opaqueHandle);
             //copy shader handle
-            memcpy(missData, opaqueHandle, mRayTracingProperties.shaderGroupHandleSize);
+            memcpy(missData + (missSize * i), opaqueHandle, opaqueHandleSize);
         }
         uint8_t* hitData = hitSize > 0 ? (uint8_t*)MapBuffer(outSBT.HitGroupBuffer) : nullptr;
         for(uint32_t i = 0; hitData && i < hitCount; i++)
@@ -162,7 +162,7 @@ namespace vr
             uint32_t shaderIndex = sbt.HitGroupIndices[i];
             GetHandlesForSBTBuffer(pipeline, shaderIndex, 1, opaqueHandle);
             //copy shader handle
-            memcpy(hitData, opaqueHandle, mRayTracingProperties.shaderGroupHandleSize);
+            memcpy(hitData + (hitSize * i), opaqueHandle, opaqueHandleSize);
         }
         uint8_t* callData = callSize > 0 ? (uint8_t*)MapBuffer(outSBT.CallableBuffer) : nullptr;
         for(uint32_t i = 0; callData && i < callCount; i++)
@@ -170,7 +170,7 @@ namespace vr
             uint32_t shaderIndex = sbt.CallableIndices[i];
             GetHandlesForSBTBuffer(pipeline, shaderIndex, 1, opaqueHandle);
             //copy shader handle
-            memcpy(callData, opaqueHandle, mRayTracingProperties.shaderGroupHandleSize);
+            memcpy(callData + (callSize * i), opaqueHandle, opaqueHandleSize);
         }
 
         //unmap all the buffers

--- a/Source/VulkanBuilder/VulkanBuilder.cpp
+++ b/Source/VulkanBuilder/VulkanBuilder.cpp
@@ -21,10 +21,11 @@ namespace vr
     static std::vector<const char*> RayTracingExtensions = {
         VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
         VK_KHR_RAY_QUERY_EXTENSION_NAME,
-        VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
         VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
         VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME,
-        VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME // required by accel struct extension
+        VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME, // required by accel struct extension
+        VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME,
+        VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME, // Required by Vulray if using Descriptors that vulray creates
     };
 
     std::vector<const char*> GetRequiredExtensionsForVulray()


### PR DESCRIPTION
New pipeline API rework that allows for the creation of precompiled pipelines and linking them into a single pipeline which is important for ray tracing. `vr::ShaderBindingTable` is split into two separate structs: `vr::RayTracingShaderCollection` and `vr::ShaderBindingTableInfo`. `vr::RayTracingShaderCollection` can be compiled into a pipeline library or a single pipeline. When creating the pipeline library, all of them must share the same settings. The settings struct is `vr::PipelineSettings`. Then the user can chose to create a single pipeline with a vector of `vr::RayTracingShaderCollection` which is then used to create the SBT.

This creates dynamism in the pipeline creation as all the shaders don't have to be compiled every time a new shader group is added.

For future work, SBT resize functionality will be added to accomodate for any added shader groups in the pipeline.