### PR TITLE
Sbt extend

### DIFF
--- a/Include/Vulray/SBT.h
+++ b/Include/Vulray/SBT.h
@@ -5,10 +5,10 @@ namespace vr
     /// @brief Enum that defines the type of shader in the shader binding table
     enum class ShaderGroup : uint8_t
     {
-        RayGen = 0,
-        Miss = 1,
-        HitGroup = 2,
-        Callable = 3
+        RayGen      = 0,
+        Miss        = 1,
+        HitGroup    = 2,
+        Callable    = 3
     };
 
     /// @brief Contains all shaders that will be used in a hit group of an SBT
@@ -67,33 +67,40 @@ namespace vr
     ///  link to a single pipeline, the settigns should be the same for all pipelines
     struct PipelineSettings
     {
-        vk::PipelineLayout PipelineLayout;
+        vk::PipelineLayout PipelineLayout   = nullptr;
 
         /// @brief The maximum number of levels of recursion allowed in the pipeline
-        uint32_t MaxRecursionDepth = 1;
+        uint32_t MaxRecursionDepth          = 1;
 
         /// @brief The maximum size of the payload in bytes
-        uint32_t MaxPayloadSize = 0;
+        uint32_t MaxPayloadSize             = 0;
 
         /// @brief The maximum size of the hit attribute in bytes in HitGroups
-        uint32_t MaxHitAttributeSize = 0;
+        uint32_t MaxHitAttributeSize        = 0;
     };
 
     /// @brief Structure that defines the information needed to create a shader binding table
     struct ShaderBindingTableInfo
     {
         /// @brief The size of each ray gen shader record in bytes
-        uint32_t RayGenShaderRecordSize = 0;
+        uint32_t RayGenShaderRecordSize     = 0;
 
         /// @brief The size of each miss shader record in bytes
-        uint32_t MissShaderRecordSize = 0;
+        uint32_t MissShaderRecordSize       = 0;
 
         /// @brief The size of each hit group shader record in bytes
-        uint32_t HitGroupRecordSize = 0;
+        uint32_t HitGroupRecordSize         = 0;
 
         /// @brief The size of each callable shader record in bytes
-        uint32_t CallableShaderRecordSize = 0;
+        uint32_t CallableShaderRecordSize   = 0;
 
+        /// If expecting more shaders than the pipeline has, reserve space for them
+        /// The SBT for each buffer will contain space for (***Indices.size() + Reserve***)
+
+        uint32_t ReserveRayGenGroups    = 0;
+        uint32_t ReserveMissGroups      = 0;
+        uint32_t ReserveHitGroups       = 0;
+        uint32_t ReserveCallableGroups  = 0;
 
         /// Graph of how the shaders might be mixed in a full pipeline.
         /// The shaders can be mixed in any way, but this is just an example
@@ -131,16 +138,16 @@ namespace vr
 
 
         /// @brief These vectors contain where the raygen shaders live in the pipeline
-        std::vector<uint32_t> RayGenIndices = {};
+        std::vector<uint32_t> RayGenIndices     = {};
 
         /// @brief These vectors where the miss shaders live in the pipeline
-        std::vector<uint32_t> MissIndices = {};
+        std::vector<uint32_t> MissIndices       = {};
 
         /// @brief These vectors where the hit group shaders live in the pipeline
-        std::vector<uint32_t> HitGroupIndices = {};
+        std::vector<uint32_t> HitGroupIndices   = {};
 
         /// @brief These vectors where the callable shaders live in the pipeline
-        std::vector<uint32_t> CallableIndices = {};
+        std::vector<uint32_t> CallableIndices   = {};
     };
 
 }

--- a/Include/Vulray/VulrayDevice.h
+++ b/Include/Vulray/VulrayDevice.h
@@ -533,13 +533,7 @@ namespace vr
         /// ready to be used in dispatching rays.
         [[nodiscard]] SBTBuffer CreateSBT(vk::Pipeline pipeline, const ShaderBindingTableInfo& sbt);
 
-        /// @brief Extends the SBT buffer with the given shader binding table info.
-        /// Internally calls CanSBTFitShaders(...) to check if the shaders can fit in the SBT buffer, returns false if the shaders cannot fit.
-        /// Then the SBT buffer should be recreated with CreateSBT(...) function.
-        /// @param pipeline The pipeline that will be used to extend the SBT buffer
-        /// @param buffer The SBT buffer that will be extended
-        /// @param sbtInfo The shader binding table info that will be used to extend the SBT buffer
-        bool ExtendSBT(vk::Pipeline pipeline, SBTBuffer& buffer, const ShaderBindingTableInfo& sbtInfo);
+        bool RebuildSBT(vk::Pipeline pipeline, SBTBuffer& buffer, const ShaderBindingTableInfo& sbt);
 
         /// @brief Checks if the shaders can fit in the SBT buffer 
         /// @param buffer The SBT buffer that will be checked

--- a/Include/Vulray/VulrayDevice.h
+++ b/Include/Vulray/VulrayDevice.h
@@ -533,7 +533,25 @@ namespace vr
         /// ready to be used in dispatching rays.
         [[nodiscard]] SBTBuffer CreateSBT(vk::Pipeline pipeline, const ShaderBindingTableInfo& sbt);
 
+        /// @brief Rebuilds the SBT buffer with the new shader binding table info
+        /// @param pipeline The pipeline that will be used to rebuild the SBT buffer
+        /// @param buffer The SBT buffer that will be rebuilt
+        /// @param sbt The information about the shader binding table, must contain the indices of the shader groups in the pipeline
+        /// @return True if the SBT buffer was rebuilt successfully, false otherwise, because the SBT buffer is not big enough
+        /// to fit all the shaders in the shader binding table info, then the user should call CreateSBT(...) to create a new SBT buffer and
+        /// reserve more space for the shaders.
+        /// @note This function doesn't reallocate the SBT buffer, it just rewrites the new opaque handles to the buffer.
+        /// So you don't have to WriteToSBT(...) again after rebuilding the SBT buffer.
         bool RebuildSBT(vk::Pipeline pipeline, SBTBuffer& buffer, const ShaderBindingTableInfo& sbt);
+
+        /// @brief Copies the whole SBT from a buffer to another, including the opaque handles.
+        /// @param dst The SBT buffer that will be copied to
+        /// @param src The SBT buffer that will be copied from
+        /// @note dst must have the same or bigger size than src for all the SBT buffers.
+        /// @example SBT too small, so create a new SBT buffer with bigger size and copy the old SBT to the new one. 
+        /// Then call RebuildSBT(...) to rewrite the opaque handles to the new SBT buffer, because SBT won't function with the old opaque handles.
+        /// You would want to do this, because it copies the shader records, so you don't have to call WriteToSBT(...) again for even the old shader records.
+        void CopySBT(SBTBuffer& src, SBTBuffer& dst);
 
         /// @brief Checks if the shaders can fit in the SBT buffer 
         /// @param buffer The SBT buffer that will be checked

--- a/Source/RayTracingPipeline.cpp
+++ b/Source/RayTracingPipeline.cpp
@@ -221,6 +221,17 @@ namespace vr
         return std::make_pair(res.value, sbtInfo);
     }
 
+    std::pair<vk::Pipeline, ShaderBindingTableInfo> VulrayDevice::CreateRayTracingPipeline(const std::vector<RayTracingShaderCollection> &shaderCollections, PipelineSettings &settings, ShaderBindingTableInfo &sbtInfoOld, vk::PipelineCreateFlags flags, vk::DeferredOperationKHR deferredOp)
+    {
+        std::pair<vk::Pipeline, ShaderBindingTableInfo> pipelineInfo = CreateRayTracingPipeline(shaderCollections, settings, flags, deferredOp);
+        pipelineInfo.second.RayGenShaderRecordSize = sbtInfoOld.RayGenShaderRecordSize;
+        pipelineInfo.second.MissShaderRecordSize = sbtInfoOld.MissShaderRecordSize;
+        pipelineInfo.second.HitGroupRecordSize = sbtInfoOld.HitGroupRecordSize;
+        pipelineInfo.second.CallableShaderRecordSize = sbtInfoOld.CallableShaderRecordSize;
+
+        return pipelineInfo;
+    }
+    
     void VulrayDevice::CreatePipelineLibrary(RayTracingShaderCollection &shaderCollection,
                                              PipelineSettings &settings,
                                              vk::PipelineCreateFlags flags,


### PR DESCRIPTION
add functionality to rebuild the SBT, because applications can have massive SBT's and the ability to rebuild them for new pipelines is important.